### PR TITLE
[codex] Fix shadowJar on Gradle 9

### DIFF
--- a/buildSrc/src/main/kotlin/mc-targets-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/mc-targets-convention.gradle.kts
@@ -48,6 +48,7 @@ tasks.shadowJar {
     configurations = listOf(shadowCommon)
     archiveClassifier.set("dev-shadow")
     destinationDirectory.set(layout.projectDirectory.dir("devlibs"))
+    includeEmptyDirs = false
 }
 
 tasks.remapJar {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ kotlinforforge = '5.7.0' # https://www.curseforge.com/minecraft/mc-mods/kotlin-f
 forgified-fabric-api = '0.104.0+2.0.13+1.21.1'
 
 # plugins
-shadow = '8.1.1'
+shadow = '9.3.2'
 spotless = '8.0.0'
 
 architectury-loom = '1.9-SNAPSHOT'
@@ -52,7 +52,7 @@ kotlin-jvm = { id = 'org.jetbrains.kotlin.jvm', version.ref = 'kotlin' }
 kotlin-serialization = { id = 'org.jetbrains.kotlin.plugin.serialization', version.ref = 'kotlin' }
 architectury-plugin = { id = 'architectury-plugin', version.ref = 'architectury-plugin' }
 architectury-loom = { id = 'dev.architectury.loom', version.ref = 'architectury-loom' }
-shadow = { id = 'com.github.johnrengelman.shadow', version.ref = 'shadow' }
+shadow = { id = 'com.gradleup.shadow', version.ref = 'shadow' }
 spotless = { id = 'com.diffplug.spotless', version.ref = 'spotless' }
 
 [bundles]


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions failure in `:fabric:shadowJar` when writing `META-INF` into the dev shadow jar.

## Root Cause

The build was still using the legacy Shadow plugin coordinate `com.github.johnrengelman.shadow` at `8.1.1`. With the Gradle 9.4.1 wrapper, that plugin path can fail while visiting directory entries and writing the ZIP, including the `META-INF` entry shown in the CI log.

## Changes

- Move Shadow to the maintained `com.gradleup.shadow` plugin at `9.3.2`.
- Disable empty directory entries for `shadowJar` so repeated directory entries do not participate in the archive output.

## Validation

- `:buildSrc:compileKotlin` passed via IntelliJ MCP Gradle.
- `:fabric:shadowJar -x :common:transformProductionFabric --stacktrace` passed via IntelliJ MCP Gradle.
- `:neoforge:shadowJar -x :common:transformProductionNeoForge --stacktrace` passed via IntelliJ MCP Gradle.

Full local `:fabric:shadowJar --stacktrace` still stops earlier at `:common:transformProductionFabric` with an Architectury Transformer empty mapping path error. That is separate from the Shadow `META-INF` failure shown in the CI log.